### PR TITLE
Add missing planfull page

### DIFF
--- a/planfull.html
+++ b/planfull.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9RWXX5XV4W"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9RWXX5XV4W');
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
+    <title>Full Plan | Canine Kingdom Co</title>
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <a href="index.html">Home</a>
+            <a href="plan.html">Plan</a>
+            <a href="our-story.html">Our Story</a>
+            <a href="services.html">Services</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section class="plan-section">
+            <div class="centered-image">
+                <img src="img2.png" alt="Plan Image" class="resizable-image">
+            </div>
+            <div style="max-width: 800px; margin: 2rem auto; text-align: center;">
+                <h2 style="font-family: 'Poppins', sans-serif; color: var(--primary-color); margin-bottom: 1rem;">Our Vision</h2>
+                <p>Canine Kingdom Co is committed to creating affordable care hubs, engaging community events and lasting rescue partnerships.</p>
+                <h2 style="font-family: 'Poppins', sans-serif; color: var(--primary-color); margin: 2rem 0 1rem;">Next Steps</h2>
+                <p>We're finalizing our rollout strategy and securing locations. Join our Facebook community to follow along as each phase unfolds.</p>
+            </div>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `planfull.html` placeholder for detailed rollout information

## Testing
- `grep -n "planfull.html" index.html plan.html`

------
https://chatgpt.com/codex/tasks/task_e_687e50961ba4832f8c3309ccd5bca1b6