### PR TITLE
Fix parallax offset causing gaps between story images

### DIFF
--- a/script.js
+++ b/script.js
@@ -269,13 +269,18 @@ function initializeParallax() {
     function updateParallax() {
         const scrolled = window.pageYOffset;
         const parallaxElements = document.querySelectorAll('.hero-image, .full-screen-image');
-        
-        parallaxElements.forEach((element, index) => {
+
+        parallaxElements.forEach((element) => {
             const speed = 0.5;
-            const yPos = -(scrolled * speed);
+            const elementTop = element.offsetTop;
+            const distance = scrolled - elementTop;
+            let yPos = -(distance * speed);
+            const maxOffset = 0;
+            const minOffset = -element.offsetHeight;
+            yPos = Math.min(Math.max(yPos, minOffset), maxOffset);
             element.style.transform = `translate3d(0, ${yPos}px, 0)`;
         });
-        
+
         ticking = false;
     }
 


### PR DESCRIPTION
## Summary
- clamp parallax translation so elements never slide past 0 or their height

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e61379d78832fbc19bbf45ae8bdcd