### PR TITLE
Fix parallax offset clamping

### DIFF
--- a/script.js
+++ b/script.js
@@ -275,7 +275,9 @@ function initializeParallax() {
             const elementTop = element.offsetTop;
             const distance = scrolled - elementTop;
             let yPos = -(distance * speed);
-            yPos = Math.max(yPos, -element.offsetHeight);
+            const maxOffset = 0;
+            const minOffset = -element.offsetHeight;
+            yPos = Math.min(Math.max(yPos, minOffset), maxOffset);
             element.style.transform = `translate3d(0, ${yPos}px, 0)`;
         });
 


### PR DESCRIPTION
## Summary
- clamp hero image parallax offset to prevent overshoot

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_687e6d3bbc4c832f9261444d3fb0fd4b