### PR TITLE
Fix padding between story images

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -413,7 +413,7 @@ section {
 
     .full-screen-image {
         background-attachment: scroll;
-        padding: 1rem;
+        padding: 0;
         min-height: 100vh;
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- remove padding in mobile media query for `.full-screen-image` so stacked images have no gap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e8584e774832fab116790de43acaa